### PR TITLE
explicitly allow more attribute accesses

### DIFF
--- a/server.py
+++ b/server.py
@@ -97,6 +97,10 @@ def start_service(host: str, port: int, bv: binaryninja.binaryview.BinaryView) -
                 port=p,
                 protocol_config={
                     "allow_public_attrs": True,
+                    "allow_all_attrs": True,
+                    "allow_getattr": True,
+                    "allow_setattr": True,
+                    "allow_delattr": True,
                 },
             )
             break


### PR DESCRIPTION
without this, it will cause things like setting function names to fail. we need to explicitly tell `rpyc` to allow us to `setattr` and similar things.