### PR TITLE
Modify the installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ This plugin requires the installation of the [`rpyc`](https://rpyc.readthedocs.i
 
 Install the files in the Binary Ninja plugin directory:
 
-### linux/osx
+### Linux
 
 ```bash
-git clone --depth 1 https://github.com/hugsy/binja-headless "~/.config/Binary Ninja/plugins/binja-headless"
+git clone --depth 1 https://github.com/hugsy/binja-headless "$HOME/.binaryninja/plugins/binja-headless"
 ```
 
-### windows
+### macOS
+
+```bash
+git clone --depth 1 https://github.com/hugsy/binja-headless "$HOME/Library/Application Support/Binary Ninja/plugins/binja-headless"
+```
+
+### Windows
 
 ```bash
 git clone --depth 1 https://github.com/hugsy/binja-headless "$env:AppData/Binary Ninja/plugins/binja-headless"


### PR DESCRIPTION
Hi, there ✋ 
On my macOS Sequoia 15.3, there were some issues during installation.
I've fixed them and here is why:

- `~` may leads to become an undefined behavior. In my case, it does not interpret as my home directory, it just becomes a directory name `~`. I recommend that use an environment variable instead.
- The plugin does not work even after installed correctly. Because there is difference between macOS and Linux default plugin path. (https://docs.binary.ninja/guide/plugins.html)
- I also recommend use the default plugin path in Linux as shown Binary Ninja documentation.
